### PR TITLE
fix: wrong documentation of mxm input argument

### DIFF
--- a/ci-gwas.py
+++ b/ci-gwas.py
@@ -152,7 +152,7 @@ def main():
     cuskss_parser.add_argument(
         "mxm",
         type=str,
-        help="Correlations between markers in block. Binary of floats, upper triangular, without diagonal.",
+        help="Correlations between markers in block. Binary of floats, lower triangular, with diagonal, row major.",
     )
     cuskss_parser.add_argument(
         "mxp",

--- a/cusk/apps/mps.cpp
+++ b/cusk/apps/mps.cpp
@@ -622,7 +622,7 @@ Run cuda-skeleton on a block of markers and traits with pre-computed correlation
 usage: mps cuskss <mxm> <mxp> <pxp> <block-ix> <.blocks> <alpha> <max-level> <depth> <num-samples> <outdir>
 
 arguments:
-    mxm                     correlations between markers in block. Binary of floats, upper triangular, without diagonal.
+    mxm                     correlations between markers in block. Binary of floats, lower triangular, with diagonal, row major.
     mxp                     correlations between markers in all blocks and all traits. Text format, rectangular.
     pxp                     correlations between all traits. Text format, rectangular, only upper triangle is used.
     block-ix                0-based index of the marker block in the .blocks file

--- a/cusk/src/marker_summary_stats.cpp
+++ b/cusk/src/marker_summary_stats.cpp
@@ -3,7 +3,7 @@
 
 /**
  * @brief Load mxm matrix from binary file. Assumed to contain float32 values in lower triangular
- * matrix format, including the diagonal.
+ * matrix format, including the diagonal, row major.
  */
 MarkerSummaryStats::MarkerSummaryStats(const std::string path)
 {


### PR DESCRIPTION
The README and docs said for the mxm argument of `cuskss`: "upper triangular without diagonal", which is wrong. This has to be lower triangular, row major, with diagonal included, the way that plink outputs with the `triangle` option.