### PR TITLE
add backslash if outdir has missing backslash

### DIFF
--- a/ci-gwas.py
+++ b/ci-gwas.py
@@ -391,7 +391,10 @@ def cuskss(args):
 
 
 def merge_blocks(args):
-    merged_blocks = merge_block_outputs(args.blockfile, args.cusk_output_dir)
+    out_dir = args.cusk_output_dir
+    if not out_dir.endswith("/"):
+        out_dir += "/"
+    merged_blocks = merge_block_outputs(args.blockfile, out_dir)
     merged_blocks.write_mm(f"{args.cusk_output_dir}/merged_blocks")
 
 


### PR DESCRIPTION
previsouly, a missing backslash in the string of the "output-dir' argument of "merge-block-outputs" would lead to an error like this:

```
chr15_vep_and_common ../bedfiles/chr15_vep_and_common_m11000.blocks 
Missing: cuskss_chr15_vep_and_common15_0_4643
Missing: cuskss_chr15_vep_and_common15_4644_13530
Missing: cuskss_chr15_vep_and_common15_13531_21890
Missing: cuskss_chr15_vep_and_common15_21891_28304
Missing: cuskss_chr15_vep_and_common15_28305_30664
Missing: cuskss_chr15_vep_and_common15_30665_33131
Missing: cuskss_chr15_vep_and_common15_33132_42548
Missing: cuskss_chr15_vep_and_common15_42549_44690
Missing: cuskss_chr15_vep_and_common15_44691_49492
Missing: cuskss_chr15_vep_and_common15_49493_51363
Missing: cuskss_chr15_vep_and_common15_51364_53862
Missing: cuskss_chr15_vep_and_common15_53863_55882
Missing: cuskss_chr15_vep_and_common15_55883_57270
Missing: cuskss_chr15_vep_and_common15_57271_59266
Missing: cuskss_chr15_vep_and_common15_59267_60217
Missing: cuskss_chr15_vep_and_common15_60218_66483
Traceback (most recent call last):
  File "/mnt/beegfs/robingrp/nmachnik/projects/bp_rep/rare_variants/sumstat/../ci-gwas.py", line 435, in <module>
    main()
  File "/mnt/beegfs/robingrp/nmachnik/projects/bp_rep/rare_variants/sumstat/../ci-gwas.py", line 331, in main
    args.func(args)
  File "/mnt/beegfs/robingrp/nmachnik/projects/bp_rep/rare_variants/sumstat/../ci-gwas.py", line 394, in merge_blocks
    merged_blocks = merge_block_outputs(args.blockfile, args.cusk_output_dir)
  File "/nfs/scistore17/robingrp/nmachnik/dev/ci-gwas/sepselect/merge_blocks.py", line 394, in merge_block_outputs
    sam, scm, gmi, marker_offset + bo.num_phen(), bo.num_phen(), bo.max_level()
UnboundLocalError: local variable 'bo' referenced before assignment
```

This PR fixes that by adding a backslash if there is none.